### PR TITLE
No closing brackets for media query

### DIFF
--- a/dist/jquery.postitall.css
+++ b/dist/jquery.postitall.css
@@ -896,3 +896,4 @@ input:focus, textarea:focus, div[contenteditable="true"]:focus {
         background-position: 0px -100px; }
     .trumbowyg-black .trumbowyg-fullscreen .trumbowyg-button-pane li a.trumbowyg-fullscreen-button {
       background-position: 0px -150px; }
+}


### PR DESCRIPTION
If your app or site use css aggregation, you get broken stylesheets.